### PR TITLE
Create cron and test authentication

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, jsonify, request, json, abort
+from flask import Flask, jsonify, request, json, abort, request
 import hashlib
 import psycopg2
 from dotenv import load_dotenv
@@ -19,15 +19,13 @@ def verify_authentication():
     try: 
         secret = os.environ.get('SECRET_HASH')
 
-        parse_headers = json.loads(json.dumps({**request.headers}))
-        csrf_token = parse_headers["Cookie"].split('; ')[0].split("=")[1]
-        print(csrf_token)
-        request_token = csrf_token.split("%7C")[0]
-        request_hash = csrf_token.split("%7C")[1]
-        
+        request_token = request.headers['Token']
+        request_hash =  request.headers['Hash']
+
         hasher = hashlib.sha256()
         hasher.update(f'{request_token}{secret}'.encode('utf-8'))
         secret_hash = hasher.hexdigest()
+
 
         if secret_hash != request_hash:
             abort(403)

--- a/cron/cron.py
+++ b/cron/cron.py
@@ -1,17 +1,22 @@
-import requests
 import hashlib
 import os
+import requests
 
-URL = 'http://127.0.0.1:5000/scrape' # to change to production url
-secret = 'secret' # to change to environment file
-random_bytes = os.urandom(32)
-hashed_token = hashlib.sha256(random_bytes).hexdigest()
+def lambda_handler(event, context):
+    URL = 'https://better-billboard.onrender.com/scrape'
+    secret = os.environ['secret']
+    random_bytes = os.urandom(32)
+    hashed_token = hashlib.sha256(random_bytes).hexdigest()
+    
+    hasher = hashlib.sha256()
+    hasher.update(f'{hashed_token}{secret}'.encode('utf-8'))
+    secret_hash = hasher.hexdigest()
+    
+    headers = { "token": str(hashed_token), "hash": str(secret_hash) }
+    
+    response = requests.get(URL, headers=headers)
 
-hasher = hashlib.sha256()
-hasher.update(f'{hashed_token}{secret}'.encode('utf-8'))
-secret_hash = hasher.hexdigest()
-
-headers = { "token": str(hashed_token), "hash": str(secret_hash) }
-
-r = requests.get(URL, headers=headers)
-print(r)
+    return {
+        'statusCode': response.status_code,
+        'body': response.content
+    }

--- a/cron/cron.py
+++ b/cron/cron.py
@@ -1,1 +1,17 @@
-# Cron will be here
+import requests
+import hashlib
+import os
+
+URL = 'http://127.0.0.1:5000/scrape' # to change to production url
+secret = 'secret' # to change to environment file
+random_bytes = os.urandom(32)
+hashed_token = hashlib.sha256(random_bytes).hexdigest()
+
+hasher = hashlib.sha256()
+hasher.update(f'{hashed_token}{secret}'.encode('utf-8'))
+secret_hash = hasher.hexdigest()
+
+headers = { "token": str(hashed_token), "hash": str(secret_hash) }
+
+r = requests.get(URL, headers=headers)
+print(r)

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,8 @@ To complete
 3. Change directory to the backend `$ cd api`
 4. Create a new virtual environment using `$ python -m .venv` 
 5. Change directory to the bin of the virtual environment `$ cd .venv/bin/`
-6. Change directory back to the api folder with `$ cd ../.. ` 
-7. Start the virtual environment `$ source activate` 
+6. Start the virtual environment `$ source activate` 
+7. Change directory back to the api folder with `$ cd ../.. ` 
 8. Install the requirements `pip in`stall -r requirements.txt`
 9. Start the flask server with `flask --debug run`
 10. Server will be running on http://127.0.0.1:5000

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ To complete
 Backend is written in Python and is a Flask App Deployed on Vercel 
 
 ## Cron 
-Cron a Python written AWS Lambda Function with an AWS scheduled cron event every Tuesday (32 5 ? * 3 * ). The CRON hits the backend and tell it to perform the scrape amd save it to the database. 
+Cron a Python written AWS Lambda with an AWS EventBridge cron event every Tuesday (32 5 ? * 3 * ). The CRON hits the backend and tell it to perform the scrape amd save it to the database. 
 
 # Getting Started Guide
 ## Backend 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,13 @@
 # Overview
 To complete
 
+# Implementation Details 
+## Backend 
+Backend is written in Python and is a Flask App Deployed on Vercel 
+
+## Cron 
+Cron a Python written AWS Lambda Function with an AWS scheduled cron event every Tuesday (32 5 ? * 3 * ). The CRON hits the backend and tell it to perform the scrape amd save it to the database. 
+
 # Getting Started Guide
 ## Backend 
 1. Ensure you have python installed using `$ python --version`. The project supports Python 3.12.4
@@ -15,6 +22,5 @@ To complete
 10. Server will be running on http://127.0.0.1:5000
 
 To do 
-1. cron job
-2. spin up the frontend 
-3. tidy it up 
+1. spin up the frontend 
+2. tidy it up 


### PR DESCRIPTION
# Overview 
* I deployed the CRON job that hits the backend and tells the app to perform the scrape every Tuesday. That endpoint is authenticated, so I had to test that code and now it all works 
* Copy-paste the cron from AWS into the cron.py file 
* Update readme with some basic details. Readme needs to be done much better, but it OK for now.

# Artifacts
![Screenshot 2024-09-23 at 9 39 40 PM](https://github.com/user-attachments/assets/f01f4258-c69d-46e5-8234-8899ac8c44b1)
![Screenshot 2024-09-23 at 9 39 44 PM](https://github.com/user-attachments/assets/1d9864d6-cb1d-4ba9-ae22-2445ccda220c)
